### PR TITLE
Improvement add show credential at profile page

### DIFF
--- a/src/pages/profile/Certificate.tsx
+++ b/src/pages/profile/Certificate.tsx
@@ -8,6 +8,9 @@ import { HttpClient } from 'src/services'
 import { AppConfig } from 'src/configs/api'
 import { useEffect, useState } from 'react'
 import { format } from 'date-fns'
+import secureLocalStorage from 'react-secure-storage'
+import { IUser } from 'src/contract/models/user'
+import localStorageKeys from 'src/configs/localstorage_keys'
 
 export type IData = {
   id: number
@@ -32,9 +35,12 @@ const Ceritificate = (props: Props) => {
   const { userId } = props
   const [data, setData] = useState<IData[]>([])
 
+  const user = secureLocalStorage.getItem(localStorageKeys.userData) as IUser
+
+  const isDataHidden = userId == user?.id || user?.team_id === 3 ? false : true
+
   const loadData = () => {
     HttpClient.get(AppConfig.baseUrl + `/user/candidate-document/?user_id=${userId}`).then(response => {
-      console.log(response)
       const itemData = response.data.documents
 
       setData(itemData)
@@ -92,26 +98,27 @@ const Ceritificate = (props: Props) => {
                   >
                     {item?.issue_at ? 'Issued date ' + format(new Date(item?.issue_at), 'LLL yyyy') : 'Issued date -'}
                   </Typography>
-
-                  <Button
-                    sx={{
-                      width: '200px',
-                      height: '37px',
-                      textTransform: 'capitalize',
-                      fontWeight: 400,
-                      fontSize: '14px',
-                      lineHeight: '21px',
-                      padding: '8px 16px 8px 16px',
-                      textAlign: 'center'
-                    }}
-                    variant='outlined'
-                    color='primary'
-                    size='medium'
-                    href={process.env.NEXT_PUBLIC_BASE_URL + '/storage/' + item.path}
-                    target='_blank'
-                  >
-                    Show Credential
-                  </Button>
+                  {!isDataHidden && (
+                    <Button
+                      sx={{
+                        width: { sm: '100%', md: '136px' },
+                        height: '37px',
+                        borderColor: 'rgba(50, 73, 122, 1) !important',
+                        textTransform: 'capitalize',
+                        fontWeight: 400,
+                        fontSize: { sm: '14px', md: '11px' },
+                        lineHeight: '21px',
+                        color: 'rgba(50, 73, 122, 1) !important'
+                      }}
+                      variant='outlined'
+                      color='primary'
+                      size='medium'
+                      href={process.env.NEXT_PUBLIC_BASE_URL + '/storage/' + item.path}
+                      target='_blank'
+                    >
+                      Show Credential
+                    </Button>
+                  )}
                 </Box>
               </Box>
             ))

--- a/src/views/profile/cocSection.tsx
+++ b/src/views/profile/cocSection.tsx
@@ -119,6 +119,29 @@ const CocSection: React.FC<ICocSectionProps> = ({ userId, userName }) => {
                       {isDataHidden ? '***** ***** *****' : item?.certificate_number}
                     </span>
                   </Typography>
+                  {!isDataHidden && (
+                    <Button
+                      variant='outlined'
+                      sx={{
+                        width: { sm: '100%', md: '136px' },
+                        height: '37px',
+                        borderColor: 'rgba(50, 73, 122, 1) !important',
+                        textTransform: 'capitalize',
+                        fontWeight: 400,
+                        fontSize: { sm: '14px', md: '11px' },
+                        lineHeight: '21px',
+                        color: 'rgba(50, 73, 122, 1) !important'
+                      }}
+                      onClick={() =>
+                        window.open(
+                          `${process.env.NEXT_PUBLIC_BASE_API}/public/data/competency/preview/${item?.id}`,
+                          '_blank'
+                        )
+                      }
+                    >
+                      Show Credential
+                    </Button>
+                  )}
                 </Box>
               </Box>
             ))

--- a/src/views/profile/copSection.tsx
+++ b/src/views/profile/copSection.tsx
@@ -122,6 +122,29 @@ const CopSection: React.FC<ICopSectionProps> = ({ userId, userName }) => {
                       {isDataHidden ? '***** ***** *****' : item?.certificate_number}
                     </span>
                   </Typography>
+                  {!isDataHidden && (
+                    <Button
+                      variant='outlined'
+                      sx={{
+                        width: { sm: '100%', md: '136px' },
+                        height: '37px',
+                        borderColor: 'rgba(50, 73, 122, 1) !important',
+                        textTransform: 'capitalize',
+                        fontWeight: 400,
+                        fontSize: { sm: '14px', md: '11px' },
+                        lineHeight: '21px',
+                        color: 'rgba(50, 73, 122, 1) !important'
+                      }}
+                      onClick={() =>
+                        window.open(
+                          `${process.env.NEXT_PUBLIC_BASE_API}/public/data/proficiency/preview/${item?.id}`,
+                          '_blank'
+                        )
+                      }
+                    >
+                      Show Credential
+                    </Button>
+                  )}
                 </Box>
               </Box>
             ))

--- a/src/views/profile/seafarerTravelDocument.tsx
+++ b/src/views/profile/seafarerTravelDocument.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography } from '@mui/material'
+import { Box, Button, Typography } from '@mui/material'
 import { format } from 'date-fns'
 import React, { useEffect, useState } from 'react'
 import secureLocalStorage from 'react-secure-storage'
@@ -97,6 +97,29 @@ const SeafarerTravelDocument: React.FC<ISeafarerTravelDocumentProps> = ({ userId
                     Travel Document No.{' '}
                     <span style={{ fontWeight: 400 }}>{isDataHidden ? '***** ***** *****' : item?.no}</span>
                   </Typography>
+                  {!isDataHidden && (
+                    <Button
+                      variant='outlined'
+                      sx={{
+                        width: { sm: '100%', md: '136px' },
+                        height: '37px',
+                        borderColor: 'rgba(50, 73, 122, 1) !important',
+                        textTransform: 'capitalize',
+                        fontWeight: 400,
+                        fontSize: { sm: '14px', md: '11px' },
+                        lineHeight: '21px',
+                        color: 'rgba(50, 73, 122, 1) !important'
+                      }}
+                      onClick={() =>
+                        window.open(
+                          `${process.env.NEXT_PUBLIC_BASE_API}/public/data/travel-document/preview/${item?.id}`,
+                          '_blank'
+                        )
+                      }
+                    >
+                      Show Credential
+                    </Button>
+                  )}
                 </Box>
               </Box>
             ))


### PR DESCRIPTION
1. Travel Document
<img width="1407" alt="image" src="https://github.com/user-attachments/assets/519c2154-385e-47ce-a7fe-d021cc93d87d">

2. COP
<img width="1407" alt="image" src="https://github.com/user-attachments/assets/ff27f544-5906-469f-b2e9-c9157d033744">

3. COC
<img width="1407" alt="image" src="https://github.com/user-attachments/assets/8bc649c8-392f-4e18-b0ad-e6df5f17d429">

4, Certificate (Non Pelaut)
<img width="1424" alt="image" src="https://github.com/user-attachments/assets/6f7effdd-8d5a-4981-aa1e-d7ffd818e092">

